### PR TITLE
2.0b Fix a typo in ParserOptions construtor

### DIFF
--- a/src/aerys/minko/type/loader/parser/ParserOptions.as
+++ b/src/aerys/minko/type/loader/parser/ParserOptions.as
@@ -105,7 +105,7 @@ package aerys.minko.type.loader.parser
 									  parser					: Class = null)
 		{
 			_loadDependencies			= loadDependencies;
-			_dependencyLoaderClosure	= _dependencyLoaderClosure || _dependencyLoaderClosure;
+			_dependencyLoaderClosure	= dependencyLoaderClosure || _dependencyLoaderClosure;
 			_mipmapTextures				= mipmapTextures;
 			_meshEffect					= meshEffect;
 			_vertexStreamUsage			= vertexStreamUsage;


### PR DESCRIPTION
dependencyLoaderClosure parameter was never used due to a typo in constructor
