### PR TITLE
2.0b Geometry.firstIndex and numTriangles properties

### DIFF
--- a/src/aerys/minko/render/DrawCall.as
+++ b/src/aerys/minko/render/DrawCall.as
@@ -55,6 +55,7 @@ package aerys.minko.render
 		// states
 		private var _indexBuffer		: IndexBuffer3DResource				= null;
 		private var _firstIndex			: int								= 0;
+		private var _numTriangles		: int								= -1;
 		
 		private var _vertexBuffers		: Vector.<VertexBuffer3DResource>	= new Vector.<VertexBuffer3DResource>(NUM_VERTEX_BUFFERS, true);
 		private var _numVertexComponents: uint								= 0;
@@ -228,6 +229,8 @@ package aerys.minko.render
 		{
 			_numVertexComponents = _vsInputComponents.length;
 			_indexBuffer		 = geometry.indexStream.resource;
+			_firstIndex			 = geometry.firstIndex;
+			_numTriangles		 = geometry.numTriangles;
 			
 			for (var i : uint = 0; i < _numVertexComponents; ++i)
 			{
@@ -328,9 +331,9 @@ package aerys.minko.render
 				context.setVertexBufferAt(i++, null);
 			
 			// draw triangles
-			context.drawTriangles(_indexBuffer.getIndexBuffer3D(context));
+			context.drawTriangles(_indexBuffer.getIndexBuffer3D(context), _firstIndex, _numTriangles);
 			
-			return _indexBuffer.numIndices / 3;
+			return _numTriangles == -1 ? _indexBuffer.numIndices / 3 : _numTriangles;
 		}
 		
 		public function setParameter(name : String, value : Object) : void

--- a/src/aerys/minko/scene/node/mesh/geometry/Geometry.as
+++ b/src/aerys/minko/scene/node/mesh/geometry/Geometry.as
@@ -56,6 +56,8 @@ package aerys.minko.scene.node.mesh.geometry
 		minko_scene var _vertexStreams		: Vector.<IVertexStream>	= null;
 
 		private var _indexStream	: IndexStream		= null;
+		private var _firstIndex		: uint				= 0;
+		private var _numTriangles	: int				= -1;
 
 		private var _boundingSphere	: BoundingSphere	= null;
 		private var _boundingBox	: BoundingBox		= null;
@@ -89,6 +91,23 @@ package aerys.minko.scene.node.mesh.geometry
 		}
 		
 		/**
+		 * First index in an IndexStream used by the geometry.
+		 */
+		public function get firstIndex(): uint
+		{
+			return _firstIndex;
+		}
+		
+		/**
+		 * Number of triangles in the geometry. Together with firstIndex specifies a
+		 * subset of IndexStream used by the geometry.
+		 */
+		public function get numTriangles(): int
+		{
+			return _numTriangles;
+		}
+		
+		/**
 		 * The bounding sphere of the 3D geometry. 
 		 * @return 
 		 * 
@@ -119,14 +138,21 @@ package aerys.minko.scene.node.mesh.geometry
 		}
 		
 		public function Geometry(vertexStreams	: Vector.<IVertexStream>	= null,
-								 indexStream	: IndexStream				= null)
+								 indexStream	: IndexStream				= null,
+								 firstIndex		: uint						= 0,
+								 numTriangles	: int						= -1)
 		{			
-			initialize(vertexStreams, indexStream);
+			initialize(vertexStreams, indexStream, firstIndex, numTriangles);
 		}
 		
 		private function initialize(vertexStreams	: Vector.<IVertexStream>	= null,
-									indexStream		: IndexStream				= null) : void
+									indexStream		: IndexStream				= null,
+									firstIndex		: uint						= 0,
+									numTriangles	: int						= -1) : void
 		{
+			_firstIndex 	= firstIndex;
+			_numTriangles	= numTriangles;
+			
 			var numVertexStreams	: int	= vertexStreams ? vertexStreams.length : 0;
 			
 			_vertexStreams = new Vector.<IVertexStream>();


### PR DESCRIPTION
This patch allows Geometry objects to use only a part of IndexStream, referenced by firstIndex and numTriangles properties. This is especially helpful if you have lots of small meshes and don't want to allocate a separate IndexBuffer for each of them (we can have only 4K buffers in Molehill, which is not that much actually). Default values have been chosen in a way that it does not affect any existing functionality
