### PR TITLE
Stencil buffer support

### DIFF
--- a/src/aerys/minko/render/effect/basic/BasicProperties.as
+++ b/src/aerys/minko/render/effect/basic/BasicProperties.as
@@ -2,14 +2,25 @@ package aerys.minko.render.effect.basic
 {
 	public class BasicProperties
 	{
-		public static const BLENDING				: String = 'blending';
-		public static const DEPTH_TEST				: String = 'depthTest';
-		public static const TRIANGLE_CULLING		: String = 'triangleCulling';
-		public static const DIFFUSE_COLOR			: String = 'diffuseColor';
-		public static const DIFFUSE_MAP				: String = 'diffuseMap';
-		public static const ALPHA_THRESHOLD			: String = 'alphaThreshold';
+		public static const BLENDING								: String = 'blending';
+		public static const DEPTH_TEST								: String = 'depthTest';
+		public static const TRIANGLE_CULLING						: String = 'triangleCulling';
+		public static const DIFFUSE_COLOR							: String = 'diffuseColor';
+		public static const DIFFUSE_MAP								: String = 'diffuseMap';
+		public static const ALPHA_THRESHOLD							: String = 'alphaThreshold';
 		
-		public static const OBJ_SPACE_NORMAL_MAP	: String = 'objSpaceNormalMap';
-		public static const TGT_SPACE_NORMAL_MAP	: String = 'tgtSpaceNormalMap';
+		public static const OBJ_SPACE_NORMAL_MAP					: String = 'objSpaceNormalMap';
+		public static const TGT_SPACE_NORMAL_MAP					: String = 'tgtSpaceNormalMap';
+		
+		public static const DEPTH_WRITE_ENABLED						: String = 'depthWriteEnabled';		
+		
+		public static const STENCIL_TRIANGLE_FACE					: String = 'stencilTriangleFace';
+		public static const STENCIL_COMPARE_MODE					: String = 'stencilCompareMode';
+		public static const STENCIL_ACTION_BOTH_PASS				: String = 'stencilActionOnBothPass';
+		public static const STENCIL_ACTION_DEPTH_FAIL				: String = 'stencilActionOnDepthFail';
+		public static const STENCIL_ACTION_DEPTH_PASS_STENCIL_FAIL	: String = 'stencilActionOnDepthPassStencilFail';
+		public static const STENCIL_REFERENCE_VALUE					: String = 'stencilReferenceValue';
+		public static const STENCIL_READ_MASK						: String = 'stencilReadMask';
+		public static const STENCIL_WRITE_MASK						: String = 'stencilWriteMask';
 	}
 }

--- a/src/aerys/minko/render/effect/basic/BasicShader.as
+++ b/src/aerys/minko/render/effect/basic/BasicShader.as
@@ -10,6 +10,7 @@ package aerys.minko.render.effect.basic
 	import aerys.minko.render.shader.part.animation.VertexAnimationShaderPart;
 	import aerys.minko.type.enum.Blending;
 	import aerys.minko.type.enum.DepthTest;
+	import aerys.minko.type.enum.StencilActions;
 	import aerys.minko.type.enum.TriangleCulling;
 	
 	/**
@@ -129,12 +130,40 @@ package aerys.minko.render.effect.basic
 			
 			var blending : uint = 
 				meshBindings.getConstant(BasicProperties.BLENDING, Blending.NORMAL);
-			
+
+			settings.depthWriteEnabled = 
+				meshBindings.getConstant(BasicProperties.DEPTH_WRITE_ENABLED, true);				
+				
 			settings.depthTest = 
 				meshBindings.getConstant(BasicProperties.DEPTH_TEST, DepthTest.LESS);
 			
 			settings.triangleCulling = 
 				meshBindings.getConstant(BasicProperties.TRIANGLE_CULLING, TriangleCulling.BACK);
+
+			settings.stencilTriangleFace = 
+				meshBindings.getConstant(BasicProperties.STENCIL_TRIANGLE_FACE, TriangleCulling.BOTH);
+				
+			settings.stencilCompareMode = 
+				meshBindings.getConstant(BasicProperties.STENCIL_COMPARE_MODE, DepthTest.EQUAL);
+				
+			settings.stencilActionOnBothPass = 
+				meshBindings.getConstant(BasicProperties.STENCIL_ACTION_BOTH_PASS, StencilActions.KEEP);
+				
+			settings.stencilActionOnDepthFail = 
+				meshBindings.getConstant(BasicProperties.STENCIL_ACTION_DEPTH_FAIL, StencilActions.KEEP);
+				
+			settings.stencilActionOnDepthPassStencilFail = 
+				meshBindings.getConstant(BasicProperties.STENCIL_ACTION_DEPTH_PASS_STENCIL_FAIL, StencilActions.KEEP);
+				
+			settings.stencilReferenceValue = 
+				meshBindings.getConstant(BasicProperties.STENCIL_REFERENCE_VALUE, 0);
+				
+			settings.stencilReadMask = 
+				meshBindings.getConstant(BasicProperties.STENCIL_READ_MASK, 255);
+				
+			settings.stencilWriteMask = 
+				meshBindings.getConstant(BasicProperties.STENCIL_WRITE_MASK, 255);
+				
 			
 			if (blending == Blending.ALPHA || blending == Blending.ADDITIVE)
 			{
@@ -144,7 +173,6 @@ package aerys.minko.render.effect.basic
 			
 			settings.blending			= blending;
 			settings.enabled			= true;
-			settings.depthWriteEnabled	= true;
 			settings.scissorRectangle	= null;
 		}
 		

--- a/src/aerys/minko/render/resource/Context3DResource.as
+++ b/src/aerys/minko/render/resource/Context3DResource.as
@@ -303,5 +303,31 @@ package aerys.minko.render.resource
 			
 			return this;
 		}
+		
+		public function setStencilReferenceValue( 	refNum		: uint 	= 0,
+													readMask	: uint 	= 255,
+													writeMask	: uint 	= 255 ) : Context3DResource			
+		{			
+			_context.setStencilReferenceValue( refNum, readMask, writeMask );
+			return this;
+		}
+		
+		public function setStencilActions( 	triangleFace					: String = 'frontAndBack', 
+											compareMode						: String = 'always', 
+											actionOnBothPass				: String = 'keep', 
+											actionOnDepthFail				: String = 'keep', 
+											actionOnDepthPassStencilFail	: String = 'keep' ) : Context3DResource
+		{			
+			_context.setStencilActions( 
+				triangleFace,
+				compareMode,
+				actionOnBothPass,
+				actionOnDepthFail,
+				actionOnDepthPassStencilFail
+			);			
+
+			return this;
+		}
+		
 	}
 }

--- a/src/aerys/minko/render/shader/ShaderSettings.as
+++ b/src/aerys/minko/render/shader/ShaderSettings.as
@@ -5,6 +5,7 @@ package aerys.minko.render.shader
 	import aerys.minko.render.resource.Context3DResource;
 	import aerys.minko.type.enum.Blending;
 	import aerys.minko.type.enum.DepthTest;
+	import aerys.minko.type.enum.StencilActions;
 	import aerys.minko.type.enum.TriangleCulling;
 	
 	import flash.geom.Rectangle;
@@ -35,14 +36,14 @@ package aerys.minko.render.shader
 		
 		private var _depthSortDrawCalls						: Boolean		= false;
 		
-		private var _stencilTriangleFace					: String		= null;
-		private var _stencilCompareMode						: String		= null;
-		private var _stencilActionOnBothPass				: String		= null;
-		private var _stencilActionOnDepthFail				: String		= null;
-		private var _stencilActionOnDepthPassStencilFail	: String		= null;
+		private var _stencilTriangleFace					: uint			= TriangleCulling.BOTH;
+		private var _stencilCompareMode						: uint			= DepthTest.ALWAYS;
+		private var _stencilActionOnBothPass				: uint			= StencilActions.KEEP;
+		private var _stencilActionOnDepthFail				: uint			= StencilActions.KEEP;
+		private var _stencilActionOnDepthPassStencilFail	: uint			= StencilActions.KEEP;
 		private var _stencilReferenceValue					: uint			= 0;
 		private var _stencilReadMask						: uint			= 255;
-		private var _sentcilWriteMask						: uint			= 255;
+		private var _stencilWriteMask						: uint			= 255;
 		
 		minko_render function get signature() : Signature
 		{
@@ -102,8 +103,7 @@ package aerys.minko.render.shader
 		{
 			_depthTest = value;
 			
-			var index : int = DepthTest.FLAGS.indexOf(value);
-			
+			var index : int = DepthTest.FLAGS.indexOf(value);			
 			if (index < 0)
 				throw new Error("Invalid depth test value: " + value);
 			
@@ -150,17 +150,111 @@ package aerys.minko.render.shader
 			_depthSortDrawCalls = value;
 		}
 		
+		public function get stencilTriangleFace():uint
+		{
+			return _stencilTriangleFace;
+		}
+		
+		public function set stencilTriangleFace( value : uint ):void 
+		{
+			_stencilTriangleFace = value;
+		}
+		
+		public function get stencilCompareMode():uint 
+		{
+			return _stencilCompareMode;
+		}
+		
+		public function set stencilCompareMode( value : uint ):void 
+		{
+			var index : int = DepthTest.FLAGS.indexOf(value);
+			
+			if (index < 0)
+				throw new Error("Invalid stencil compare mode value: " + value);
+			
+			_stencilCompareMode 	= value;
+		}
+		
+		public function get stencilActionOnBothPass():uint 
+		{
+			return _stencilActionOnBothPass;
+		}
+		
+		public function set stencilActionOnBothPass( value : uint ):void 
+		{
+			_stencilActionOnBothPass = value;
+		}
+		
+		public function get stencilActionOnDepthFail():uint 
+		{
+			return _stencilActionOnDepthFail;
+		}
+		
+		public function set stencilActionOnDepthFail( value : uint ):void 
+		{			
+			_stencilActionOnDepthFail = value;
+		}
+		
+		public function get stencilActionOnDepthPassStencilFail():uint 
+		{
+			return _stencilActionOnDepthPassStencilFail;
+		}
+		
+		public function set stencilActionOnDepthPassStencilFail( value : uint ):void 
+		{		
+			_stencilActionOnDepthPassStencilFail = value;
+		}
+		
+		public function get stencilReferenceValue():uint 
+		{
+			return _stencilReferenceValue;
+		}
+		
+		public function set stencilReferenceValue( value : uint ):void 
+		{
+			_stencilReferenceValue = value;
+		}		
+		
+		public function get stencilReadMask():uint 
+		{
+			return _stencilReadMask;
+		}
+		
+		public function set stencilReadMask( value : uint ):void 
+		{
+			_stencilReadMask = value;
+		}
+		
+		public function get stencilWriteMask():uint 
+		{
+			return _stencilWriteMask;
+		}
+		
+		public function set stencilWriteMask( value : uint ):void 
+		{
+			_stencilWriteMask = value;
+		}
+		
 		public function ShaderSettings(signature : Signature)
 		{
-			_numUses			= 0;
-			_signature			= signature;
+			_numUses								= 0;
+			_signature								= signature;
 			
-			depthTest			= DepthTest.LESS;
-			blending			= Blending.NORMAL;
-			triangleCulling		= TriangleCulling.BACK;
-			renderTarget		= null;
-			depthWriteEnabled	= true;
-			scissorRectangle	= null;
+			depthTest								= DepthTest.LESS;
+			blending								= Blending.NORMAL;
+			triangleCulling							= TriangleCulling.BACK;
+			renderTarget							= null;
+			depthWriteEnabled						= true;
+			scissorRectangle						= null;
+			
+			stencilTriangleFace 					= TriangleCulling.BOTH;
+			stencilCompareMode						= DepthTest.ALWAYS;
+			stencilActionOnBothPass					= StencilActions.KEEP;
+			stencilActionOnDepthFail				= StencilActions.KEEP;
+			stencilActionOnDepthPassStencilFail		= StencilActions.KEEP;
+			stencilReferenceValue					= 0;
+			stencilReadMask							= 255;
+			stencilWriteMask						= 255;
 		}
 		
 		public function retain() : void
@@ -177,13 +271,23 @@ package aerys.minko.render.shader
 		{
 			var clone : ShaderSettings = new ShaderSettings(signature);
 			
-			clone.depthTest = depthTest;
-			clone.blending = blending;
-			clone.triangleCulling = triangleCulling;
-			clone.renderTarget = renderTarget;
-			clone.depthWriteEnabled	= depthWriteEnabled;
-			clone.scissorRectangle = scissorRectangle;
-			clone.depthSortDrawCalls = depthSortDrawCalls;
+			clone.priority 								= priority;
+			clone.depthTest 							= depthTest;
+			clone.blending 								= blending;
+			clone.triangleCulling 						= triangleCulling;
+			clone.renderTarget 							= renderTarget;
+			clone.depthWriteEnabled						= depthWriteEnabled;
+			clone.scissorRectangle 						= scissorRectangle;
+			clone.depthSortDrawCalls 					= depthSortDrawCalls;
+			
+			clone.stencilTriangleFace 					= stencilTriangleFace;
+			clone.stencilCompareMode 					= stencilCompareMode;
+			clone.stencilActionOnBothPass 				= stencilActionOnBothPass;
+			clone.stencilActionOnDepthFail 				= stencilActionOnDepthFail;
+			clone.stencilActionOnDepthPassStencilFail 	= stencilActionOnDepthPassStencilFail;
+			clone.stencilReferenceValue 				= stencilReferenceValue;
+			clone.stencilReadMask		 				= stencilReadMask;
+			clone.stencilWriteMask						= stencilWriteMask;
 			
 			return clone;
 		}
@@ -221,7 +325,20 @@ package aerys.minko.render.shader
 			
 			context.setBlendFactors(_blendingSource, _blendingDest);
 			context.setCulling(_triangleCullingStr);
-		}
-		
+			
+			context.setStencilReferenceValue(
+				_stencilReferenceValue,
+				_stencilReadMask,
+				_stencilWriteMask
+			);			
+			
+			context.setStencilActions(
+				TriangleCulling.STRINGS[stencilTriangleFace],
+				DepthTest.STRINGS[DepthTest.FLAGS.indexOf(stencilCompareMode)],
+				StencilActions.STRINGS[stencilActionOnBothPass],
+				StencilActions.STRINGS[stencilActionOnDepthFail],
+				StencilActions.STRINGS[stencilActionOnDepthPassStencilFail]
+			);
+		}		
 	}
 }

--- a/src/aerys/minko/type/enum/StencilActions.as
+++ b/src/aerys/minko/type/enum/StencilActions.as
@@ -1,0 +1,28 @@
+package aerys.minko.type.enum 
+{
+	import aerys.minko.ns.minko_render;
+	import flash.display3D.Context3DStencilAction;
+
+	public class StencilActions 
+	{
+		public static const DECREMENT_SATURATE		: int = 0;
+		public static const DECREMENT_WRAP			: int = 1;
+		public static const INCREMENT_SATURATE		: int = 2;
+		public static const INCREMENT_WRAP			: int = 3;		
+		public static const INVERT					: int = 4;
+		public static const KEEP					: int = 5;
+		public static const SET						: int = 6;
+		public static const ZERO					: int = 7;
+
+		minko_render static const STRINGS : Vector.<String> = new <String>[
+			Context3DStencilAction.DECREMENT_SATURATE,
+			Context3DStencilAction.DECREMENT_WRAP,
+			Context3DStencilAction.INCREMENT_SATURATE,
+			Context3DStencilAction.INCREMENT_WRAP,
+			Context3DStencilAction.INVERT,
+			Context3DStencilAction.KEEP,
+			Context3DStencilAction.SET,
+			Context3DStencilAction.ZERO
+		];		
+	}
+}


### PR DESCRIPTION
- BasicProperties.as: reads stencil parameter bindings and also reads
  depthWriteEnabled, it is important for the effect but was missing
  functionality.
- BasicShader.as: initializesettings changed according to new basic
  properties
- Context3DResource.as: support native stencil operations
- ShaderSettings.as: was missing the priority property in the clone
  function and now support stencil operations.
- StencilActions.as: contains enumerations for stencil operations
