### PR TITLE
2.0b Fix for broken ATF texture support in TextureResource.setContentFromAtf()

### DIFF
--- a/src/aerys/minko/render/resource/texture/TextureResource.as
+++ b/src/aerys/minko/render/resource/texture/TextureResource.as
@@ -122,6 +122,7 @@ package aerys.minko.render.resource.texture
 		public function setContentFromATF(atf : ByteArray) : void
 		{
 			_atf			= atf;
+			_bitmapData		= null;
 			_update 		= true;
 			
 			atf.position 	= 6;


### PR DESCRIPTION
When I updated to the latest github version of the engine, I noticed that all my ATF textures have suddenly gone black =) After some investigation I've found that in one of the latest commits TextureResource is now initialized with 1x1 bitmap by default (I'm not sure why it's necessary, from my experience everything worked fine without it). But it is not reset to null when ATF content is actually loaded and TextureResource behaves like it really has bitmap data, not ATF
