### PR TITLE
2.0b IVertexStream.name property and related methods

### DIFF
--- a/src/aerys/minko/scene/node/mesh/geometry/Geometry.as
+++ b/src/aerys/minko/scene/node/mesh/geometry/Geometry.as
@@ -232,6 +232,40 @@ package aerys.minko.scene.node.mesh.geometry
 			_vertexStreams[index] = vertexStream;
 		}
 		
+		/**
+		 * Get the IVertexStream objects by name. If there is no such stream, returns null.
+		 * 
+		 * @param	name
+		 * @return
+		 */
+		public function getVertexStreamByName(name : String) : IVertexStream
+		{
+			for (var i : int = 0, n : int = _vertexStreams.length; i < n; i++)
+			{
+				var stream : IVertexStream = _vertexStreams[i].getStreamByName(name);
+				
+				if (stream != null)
+					return stream;
+			}
+				
+			return null;
+		}
+		
+		/**
+		 * Get the index of a named IVertexStream object. If there is no such stream, returns -1.
+		 * 
+		 * @param	name
+		 * @return
+		 */
+		public function getVertexStreamIndex(name : String) : int
+		{
+			for (var i : int = 0, n : int = _vertexStreams.length; i < n; i++)
+				if (_vertexStreams[i].getStreamByName(name))
+					return i;
+					
+			return -1;
+		}
+		
 		private function vertexStreamBoundsChangedHandler(stream	: IVertexStream) : void
 		{
 			updateBoundingVolumes();

--- a/src/aerys/minko/type/stream/IVertexStream.as
+++ b/src/aerys/minko/type/stream/IVertexStream.as
@@ -6,6 +6,7 @@ package aerys.minko.type.stream
 
 	public interface IVertexStream
 	{
+		function get name()		: String;
 		function get format() 	: VertexFormat;
 		function get length()	: uint;
 		
@@ -15,6 +16,7 @@ package aerys.minko.type.stream
 		function disposeLocalData(waitForUpload : Boolean = true) : void;
 		function deleteVertexByIndex(index : uint) : Boolean;
 		function getStreamByComponent(component : VertexComponent) : VertexStream;
+		function getStreamByName(name : String) : IVertexStream;
 		function dispose() : void;
 	}
 }

--- a/src/aerys/minko/type/stream/VertexStream.as
+++ b/src/aerys/minko/type/stream/VertexStream.as
@@ -22,6 +22,7 @@ package aerys.minko.type.stream
 		minko_stream var _data			: Vector.<Number>	= null;
 		minko_stream var _localDispose	: Boolean			= false;
 
+		private var _name				: String					= null;
 		private var _usage				: uint						= 0;
 		private var _format				: VertexFormat				= null;
 		private var _resource			: VertexBuffer3DResource	= null;
@@ -38,6 +39,16 @@ package aerys.minko.type.stream
 		
 		private var _changed			: Signal					= new Signal('VertexStream.changed');
 		private var _boundsChanged		: Signal					= new Signal('VertexStream.boundsChanged');
+		
+		public function get name() : String
+		{
+			return _name;
+		}
+		
+		public function set name(val : String) : void
+		{
+			_name = val;
+		}
 		
 		public function get format() : VertexFormat
 		{
@@ -191,6 +202,11 @@ package aerys.minko.type.stream
 		public function getStreamByComponent(vertexComponent : VertexComponent) : VertexStream
 		{
 			return _format.hasComponent(vertexComponent) ? this : null;
+		}
+		
+		public function getStreamByName(name : String) : IVertexStream
+		{
+			return _name == name ? this : null;
 		}
 
 		public function get(i : uint) : Number

--- a/src/aerys/minko/type/stream/VertexStreamList.as
+++ b/src/aerys/minko/type/stream/VertexStreamList.as
@@ -9,6 +9,7 @@ package aerys.minko.type.stream
 	{
 		use namespace minko_stream;
 
+		private var _name			: String				= null;
 		private var _streams		: Vector.<VertexStream>	= new Vector.<VertexStream>();
 		private var _format			: VertexFormat			= new VertexFormat();
 		private var _usage			: uint					= 0;
@@ -16,6 +17,16 @@ package aerys.minko.type.stream
 		private var _changed		: Signal				= new Signal('VertexStreamList.changed');
 		private var _boundsChanged	: Signal				= new Signal('VertexStream.boundsChanged');
 
+		public function get name() : String
+		{
+			return _name;
+		}
+		
+		public function set name(val : String) : void
+		{
+			_name = val;
+		}
+		
 		public function get usage()	: uint
 		{
 			return _usage;
@@ -93,6 +104,26 @@ package aerys.minko.type.stream
 				if (_streams[i].format.hasComponent(vertexComponent))
 					return _streams[i];
 
+			return null;
+		}
+		
+		public function getStreamByName(name : String) : IVertexStream
+		{
+			if (_name == name)
+			{
+				return this;
+			}
+			else
+			{
+				for (var i : int = 0, n : int = _streams.length; i < n; i++)
+				{
+					var stream : IVertexStream = _streams[i].getStreamByName(name);
+					
+					if (stream != null)
+						return stream;
+				}
+			}
+			
 			return null;
 		}
 


### PR DESCRIPTION
I found it useful to have names on IVertexStream objects. For example, to identify animation keyframes. Thus, I've added name property and getStreamByName() method to IVertexStream interface and VertexStream/VertexStreamList classes. Also I've added getVertexStreamByName() and getVertexStreamIndex() methods to Geometry class to easily retrieve vertex stream or its index by name. Hope you'll find it useful too.
