### PR TITLE
Fixed code to remove warnings when compiling with ASC2

### DIFF
--- a/src/aerys/minko/scene/controller/light/LightShadowController.as
+++ b/src/aerys/minko/scene/controller/light/LightShadowController.as
@@ -23,8 +23,6 @@ package aerys.minko.scene.controller.light
 	import aerys.minko.type.binding.DataBindings;
 	import aerys.minko.type.enum.ShadowMappingQuality;
 	import aerys.minko.type.enum.ShadowMappingType;
-	
-	import flashx.textLayout.factory.TruncationOptions;
 
 	public class LightShadowController extends LightController
 	{

--- a/src/aerys/minko/scene/node/Group.as
+++ b/src/aerys/minko/scene/node/Group.as
@@ -159,8 +159,7 @@ package aerys.minko.scene.node
             
             for (var childId : uint = 0; childId < numChildren; ++childId)
             {
-                var child : ISceneNode = _children[childId];
-                
+                child = _children[childId];
                 child.added.execute(child, ancestor);
             }
         }
@@ -171,8 +170,7 @@ package aerys.minko.scene.node
             
             for (var childId : uint = 0; childId < numChildren; ++childId)
             {
-                var child : ISceneNode = _children[childId];
-                
+                child = _children[childId];
                 child.removed.execute(child, ancestor);
             }
         }

--- a/src/aerys/minko/scene/node/light/DirectionalLight.as
+++ b/src/aerys/minko/scene/node/light/DirectionalLight.as
@@ -131,7 +131,7 @@ package aerys.minko.scene.node.light
 										 shadowWidth		: Number	= 20,
 										 shadowQuality		: uint		= 0,
 										 shadowSpread		: uint		= 1,
-                                         shadowBias         : uint      = .002)
+                                         shadowBias         : Number    = .002)
 		{
 			super(
 				new DirectionalLightController(),

--- a/src/aerys/minko/scene/node/light/PointLight.as
+++ b/src/aerys/minko/scene/node/light/PointLight.as
@@ -140,7 +140,7 @@ package aerys.minko.scene.node.light
 								   shadowMapSize		: uint		= 512,
 								   shadowZNear			: Number	= 0.1,
 								   shadowZFar			: Number	= 1000.,
-                                   shadowBias           : uint      = 1. / 256. / 256.)
+                                   shadowBias           : Number    = 1. / 256. / 256.)
 		{
 			super(
 				new PointLightController(),

--- a/src/aerys/minko/scene/node/light/SpotLight.as
+++ b/src/aerys/minko/scene/node/light/SpotLight.as
@@ -180,7 +180,7 @@ package aerys.minko.scene.node.light
 								  shadowZFar			: Number	= 1000,
 								  shadowQuality			: uint		= 0,
 								  shadowSpread			: uint		= 1,
-                                  shadowBias            : uint      = 1. / 256. / 256.)
+                                  shadowBias            : Number    = 1. / 256. / 256.)
 		{
 			super(
 				new SpotLightController(),


### PR DESCRIPTION
Fixed a few small sections of code that were throwing warnings when compiling with ASC2 out of FlashDevelop 4.4.
