### PR TITLE
added a null check on the bounding box of the geometry 

### DIFF
--- a/src/aerys/minko/scene/node/Mesh.as
+++ b/src/aerys/minko/scene/node/Mesh.as
@@ -243,6 +243,10 @@ package aerys.minko.scene.node
 			if (!(_tag & tag))
 				return -1;
 			
+			if(_ctrl.geometry.boundingBox == null) {
+				return -1;
+			}
+			
 			return _ctrl.geometry.boundingBox.testRay(
 				ray,
 				getWorldToLocalTransform(),


### PR DESCRIPTION
LineGeometry doesn't have any so it breaks the PickingController and raycasting
