### PR TITLE
Fixing clone MasterAnimationController problem

### DIFF
--- a/src/aerys/minko/scene/controller/animation/MasterAnimationController.as
+++ b/src/aerys/minko/scene/controller/animation/MasterAnimationController.as
@@ -166,8 +166,8 @@ package aerys.minko.scene.controller.animation
 		override public function clone():AbstractController
 		{			
 			var newController : MasterAnimationController = new MasterAnimationController(_animations);
-			newController._labelNames = _labelNames;
-			newController._labelTimes = _labelTimes;
+			newController._labelNames = _labelNames.concat();
+			newController._labelTimes = _labelTimes.concat();
 			
 			return newController;
 		}


### PR DESCRIPTION
I don't know if it'll be useful to you but to clone properly MasterAnimationController you forgot to clone vectors _labelNames and _labelTimes of this class
