### PR TITLE
add viewport property to renderer

### DIFF
--- a/framework/include/minko/component/Renderer.hpp
+++ b/framework/include/minko/component/Renderer.hpp
@@ -51,6 +51,7 @@ namespace minko
 			std::unordered_map<SurfacePtr, DrawCallList>				_surfaceDrawCalls; 
 
 			unsigned int												_backgroundColor;
+                    render::ScissorBox _viewportBox;
 			std::shared_ptr<SceneManager>								_sceneManager;
 			Signal<Ptr>::Ptr											_renderingBegin;
 			Signal<Ptr>::Ptr											_renderingEnd;
@@ -135,6 +136,15 @@ namespace minko
 			{
 				_backgroundColor = backgroundColor;
 			}
+
+                    inline void viewport( const int x, const int y, const int w, const int h)
+                        {
+                            _viewportBox.x= x;
+                            _viewportBox.y= y;
+                            _viewportBox.width= w;
+                            _viewportBox.height= h;
+                        }
+
 
 			inline
 			AbsTexturePtr


### PR DESCRIPTION
Hi,
I wanted multiple viewport in the same window but it didn't seem possible as is.
So I figured out I could add a viewportBox (like the scissorBox) to the Renderer component. The property is checked right before the DrawCalls and if set the rendering context viewport and scissor test are changed accordingly.
you use it like this:  camera->component<Renderer>()->viewport( 10, 10, 100, 100 ), the cool thing is you can just add cameras to the scene and it works.
let me know if missed something.
