### PR TITLE
Workaround for clang linking errors

### DIFF
--- a/module/clang/clang.lua
+++ b/module/clang/clang.lua
@@ -5,3 +5,8 @@ table.inject(premake.tools.clang, 'cxxflags.system', {
 table.inject(premake.tools.clang, 'ldflags.system', {
 	macosx = { "-stdlib=libc++" }
 })
+
+table.inject(premake.tools.clang, 'tools', {
+	cc = 'clang',
+	cxx = MINKO_HOME .. '/tool/lin/script/clang++.sh clang++',
+})

--- a/tool/lin/script/clang++.sh
+++ b/tool/lin/script/clang++.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+BIN="$1"
+ARGS=""
+
+shift
+
+STATIC_LIBS=""
+SHARED_LIBS=""
+
+for ARG in "$@"; do
+	if [[ $ARG = *.a ]]; then
+		STATIC_LIBS="${STATIC_LIBS} ${ARG}"
+	elif [[ $ARG = -l* ]]; then
+		SHARED_LIBS="${SHARED_LIBS} ${ARG}"
+	else
+		ARGS="${ARGS} ${ARG}"
+	fi
+done
+
+test "$verbose" != 0 && set -x
+
+${BIN} ${ARGS} ${STATIC_LIBS} ${STATIC_LIBS} ${SHARED_LIBS} ${SHARED_LIBS}


### PR DESCRIPTION
This solves issue #173.
I stripped down the g++ script, I'm not quite sure if everything is needed, but it works okay.
Is it needed for os x though?
