### PR TITLE
Options creation from other instance don't copy _effectFunction

### DIFF
--- a/framework/include/minko/file/Options.hpp
+++ b/framework/include/minko/file/Options.hpp
@@ -133,6 +133,7 @@ namespace minko
                 opt->_materialFunction = options->_materialFunction;
                 opt->_geometryFunction = options->_geometryFunction;
                 opt->_protocolFunction = options->_protocolFunction;
+                opt->_effectFunction = options->_effectFunction;
                 opt->_uriFunction = options->_uriFunction;
                 opt->_nodeFunction = options->_nodeFunction;
                 opt->_loadAsynchronously = options->_loadAsynchronously;


### PR DESCRIPTION
Hi,

`_effectFunction` is left to default value, instead of being copied from original instance.
It may be on purpose but in this case i can't find how to pass custom effectFunction to Loaders.

Pierre
