### PR TITLE
Changed sdl canvas to use the surplus time of the current frame instead of the previous one when waiting

### DIFF
--- a/plugin/sdl/src/minko/Canvas.cpp
+++ b/plugin/sdl/src/minko/Canvas.cpp
@@ -739,20 +739,19 @@ Canvas::step()
     auto absoluteTime = std::chrono::high_resolution_clock::now();
     _relativeTime   = 1e-6f * std::chrono::duration_cast<std::chrono::nanoseconds>(absoluteTime - _startTime).count(); // in milliseconds
     _frameDuration  = 1e-6f * std::chrono::duration_cast<std::chrono::nanoseconds>(absoluteTime - _previousTime).count(); // in milliseconds
+    _framerate = 1000.f / _frameDuration;
 
     _enterFrame->execute(that, _relativeTime, _frameDuration);
     _previousTime = absoluteTime;
 
     _backend->swapBuffers(that);
 
-    // framerate in seconds
-    _framerate = 1000.f / _frameDuration;
+    auto curFrameDuration  = 1e-6f * std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - _previousTime).count(); // in milliseconds
+    auto remainingTime = (1000.f / _desiredFramerate) - curFrameDuration;
 
-    if (_framerate > _desiredFramerate)
+    if (remainingTime > 0)
     {
-        _backend->wait(that, (1000.f / _desiredFramerate) - _frameDuration);
-
-        _framerate = _desiredFramerate;
+        _backend->wait(that, remainingTime);
     }
 }
 


### PR DESCRIPTION
The current implementation uses the duration of the previous frame to calculate the surplus time to wait after the current frame. Is this intentional? Shouldn't the surplus time be calculated from the current frame's duration?

This causes weird behavior when vsync is off with _frameDuration alternating between 17ms and 0ms in each frame.

Also removed the manual _framerate cap so it reports the actual framerate (in case the desired framerate is not attainable). Is there any reason for manually setting it?