### PR TITLE
fixed emscripten_async_wget2_data callbacks causing compilation errors i...

### DIFF
--- a/plugin/http-loader/include/minko/net/HTTPProtocol.hpp
+++ b/plugin/http-loader/include/minko/net/HTTPProtocol.hpp
@@ -54,13 +54,13 @@ namespace minko
 
 #if defined(EMSCRIPTEN)
             static void
-            wget2CompleteHandler(unsigned int, void*, void *, unsigned int);
+            wget2CompleteHandler(void*, void *, unsigned int*);
 
             static void
-            wget2ErrorHandler(unsigned int, void*, int, const char*);
+            wget2ErrorHandler(void*, int, const char*);
 
             static void
-            wget2ProgressHandler(unsigned int, void*, int, int);
+            wget2ProgressHandler(void*, int, int);
 #endif
 
             static void

--- a/plugin/http-loader/src/minko/net/HTTPProtocol.cpp
+++ b/plugin/http-loader/src/minko/net/HTTPProtocol.cpp
@@ -176,9 +176,9 @@ HTTPProtocol::load()
             "",
             loader.get(),
             0,
-            &wget2CompleteHandler,
-            &wget2ErrorHandler,
-            &wget2ProgressHandler
+			&wget2CompleteHandler,
+			&wget2ErrorHandler,
+			&wget2ProgressHandler
         );
     }
     else
@@ -267,19 +267,19 @@ HTTPProtocol::load()
 
 #if defined(EMSCRIPTEN)
 void
-HTTPProtocol::wget2CompleteHandler(unsigned int id, void* arg, void* data, unsigned int size)
+HTTPProtocol::wget2CompleteHandler(void* arg, void* data, unsigned int* size)
 {
-    HTTPProtocol::completeHandler(arg, data, size);
+    HTTPProtocol::completeHandler(arg, data, *size);
 }
 
 void
-HTTPProtocol::wget2ErrorHandler(unsigned int id, void* arg, int code, const char* message)
+HTTPProtocol::wget2ErrorHandler(void* arg, int code, const char* message)
 {
     HTTPProtocol::errorHandler(arg, code, message);
 }
 
 void
-HTTPProtocol::wget2ProgressHandler(unsigned int id, void* arg, int loadedBytes, int totalBytes)
+HTTPProtocol::wget2ProgressHandler(void* arg, int loadedBytes, int totalBytes)
 {
     HTTPProtocol::progressHandler(arg, loadedBytes, totalBytes);
 }


### PR DESCRIPTION
Hello,

I had to make this changes to successfully build the html5 framework on Windows with the script: build_html5_no_tutorial_no_example.bat

Otherwise there were a mismatch with the signatures of the callbacks implemented in HTTPProtocol class compared to the ones in the emscripten header file. Not sure whether the wrapper methods are still necessary but at least it did build. :)
