### PR TITLE
Fix build error on Linux regarding missing pthread references.

### DIFF
--- a/module/minko/minko.project.lua
+++ b/module/minko/minko.project.lua
@@ -105,7 +105,8 @@ minko.project.application = function(name)
 		links {
 			"minko-framework",
 			"GL",
-			"m"
+			"m",
+			"pthread"
 		}
 		prelinkcommands {
 			minko.action.copy(minko.sdk.path("/framework/asset")),


### PR DESCRIPTION
I received link errors regarding pthread when building on Debian Linux, just a quick patch to include it at link time.