### PR TITLE
Adding quotes to prevent `g++.sh` from failing due to spaces in path.

### DIFF
--- a/module/gcc/gcc.lua
+++ b/module/gcc/gcc.lua
@@ -16,7 +16,7 @@ table.inject(premake.tools.gcc, 'cxxflags.system.macosx', {
 
 table.inject(premake.tools.gcc, 'tools.linux', {
 	cc = 'gcc',
-	cxx = MINKO_HOME .. '/tool/lin/script/g++.sh g++',
+	cxx = '\''..MINKO_HOME .. '/tool/lin/script/g++.sh\' g++',
 })
 
 table.inject(premake.tools.gcc, 'tools.macosx', {


### PR DESCRIPTION
When there are spaces in the path name, `make`ing minko will fail. Wrapping the
call to the script fixes this issue.

Closes #194