### PR TITLE
Tutorial and skeleton fixes

### DIFF
--- a/doc/tutorial/01-Hello_cube!.md
+++ b/doc/tutorial/01-Hello_cube!.md
@@ -121,7 +121,10 @@ To create the cube, we mainly have to:
 The following code will do those 4 steps:
 
 ```cpp
-auto cube = scene::Node::create("cube"); auto cubeMaterial = material::BasicMaterial::create(); auto cubeGeometry = geometry::CubeGeometry(assets->context()); auto cubeEffect = assets->effect("effect/Basic.effect");
+auto cube = scene::Node::create("cube");
+auto cubeMaterial = material::BasicMaterial::create();
+auto cubeGeometry = geometry::CubeGeometry(assets->context());
+auto cubeEffect = assets->effect("effect/Basic.effect");
 
 cube->addComponent(Surface::create(cubeGeometry, cubeMaterial, cubeEffect); 
 ```

--- a/doc/tutorial/06-Loading_3D_files.md
+++ b/doc/tutorial/06-Loading_3D_files.md
@@ -47,7 +47,8 @@ Access loaded files
 Once the loaded complete signal of the assetLibrary is triggered you can access the different model with the `AssetLibrary::symbol(name)` method
 
 ```cpp
-auto objModel = assets->symbol("model/model.obj"); auto daeModel = assets->symbol("model/model.dae"); 
+auto objModel = assets->symbol("model/model.obj");
+auto daeModel = assets->symbol("model/model.dae");
 ```
 
 

--- a/doc/tutorial/08-My_first_script.md
+++ b/doc/tutorial/08-My_first_script.md
@@ -97,7 +97,9 @@ The first thing to do in our C++ application code is to load the main header for
 Now, we have to initialize the Lua context to give it access to our canvas and root node without forget to add a `LuaScriptManager` thereto:
 
 ```cpp
-auto canvas = Canvas::create("Minko Tutorial - My first script", 800, 600); auto sceneManager = component::SceneManager::create(canvas); auto root = scene::Node::create("root")->addComponent(sceneManager);
+auto canvas = Canvas::create("Minko Tutorial - My first script", 800, 600);
+auto sceneManager = component::SceneManager::create(canvas);
+auto root = scene::Node::create("root")->addComponent(sceneManager);
 
 // initialization of Lua context LuaContext::initialize(argc, argv, root, canvas);
 
@@ -114,9 +116,11 @@ We can then use all the classes related to Lua scripting. Next we need to actual
 -   actually load our script(s) using `AssetLibrary::queue()` and/or `AssetLibrary::load()`.
 
 ```cpp
-// register the LuaScriptParser sceneManager->assets()->registerParser<[file::LuaScriptParser>](file::LuaScriptParser>)("lua");
+// register the LuaScriptParser
+sceneManager->assets()->registerParser<[file::LuaScriptParser>](file::LuaScriptParser>)("lua");
 
-// queue the "script/my_script.lua" script file sceneManager->assets()->queue("script/my_script.lua");
+// queue the "script/my_script.lua" script file
+sceneManager->assets()->queue("script/my_script.lua");
 
 if (assets->script("script/my_script.lua"))
 

--- a/doc/tutorial/19-Binding_the_model_to_world_transform.md
+++ b/doc/tutorial/19-Binding_the_model_to_world_transform.md
@@ -6,7 +6,8 @@ Step 1: Binding the model to world matrix
 In the [Moving objects](../tutorial/04-Moving_objects.md) tutorial, we've seen that we can add custom 3D transforms to our scene nodes using the `Transform` component. If you take a look at the code for the `Transform::initialize()` method, you'll notice that this very component declares the `transform.modelToWorldMatrix` in it's `[data::Provider`](data::Provider`):
 
 ```cpp
-// Transform.cpp void Transform::initialize() {
+// Transform.cpp 
+void Transform::initialize() {
 
  // some other code...
 

--- a/doc/tutorial/20-Binding_the_camera.md
+++ b/doc/tutorial/20-Binding_the_camera.md
@@ -102,7 +102,8 @@ Note that because we will likely need to move and orient our camera, we also add
 Because all of our camera-related properties are now handled by data binding, we also have to update our code to comment (or simply remove) any corresponding `Effect::setUniform()`:
 
 ```cpp
-//myCustomEffect->setUniform("uViewMatrix", Matrix4x4::create()); //myCustomEffect->setUniform("uProjectionMatrix", Matrix4x4::create()->perspective((float)WINDOW_WIDTH / (float)WINDOW_HEIGHT)); 
+//myCustomEffect->setUniform("uViewMatrix", Matrix4x4::create());
+//myCustomEffect->setUniform("uProjectionMatrix", Matrix4x4::create()->perspective((float)WINDOW_WIDTH / (float)WINDOW_HEIGHT)); 
 ```
 
 

--- a/doc/tutorial/21-Authoring_uber-shaders.md
+++ b/doc/tutorial/21-Authoring_uber-shaders.md
@@ -16,7 +16,11 @@ What's important to understand is how critic it is to be able to write über sha
 That's where über shaders kick in: an über shader is a single shader program that will adapt its operations according to whether some options are enabled or not. To do this, Minko leverages the GLSL pre-processor:
 
 ```c
-#ifdef SOME_OPTION // do something... #else // do something else... #endif 
+#ifdef SOME_OPTION
+// do something...
+#else
+// do something else...
+#endif 
 ```
 
 
@@ -28,9 +32,12 @@ Step 1: Updating the fragment shader
 We will take the fragment shader explained in the [Step 3 of the Create your first custom effect tutorial](../tutorial/17-Creating_a_custom_effect.md#step-3-the-fragment-shader) and update it to use a texture if the `DIFFUSE_MAP` macro is defined:
 
 ```c
-#ifdef GL_ES precision mediump float; #endif
+#ifdef GL_ES
+precision mediump float;
+#endif
 
-uniform vec4 uDiffuseColor; uniform sampler2D uDiffuseMap;
+uniform vec4 uDiffuseColor;
+uniform sampler2D uDiffuseMap;
 
 varying vec2 vVertexUv;
 
@@ -49,9 +56,12 @@ void main(void) {
 To sample the `uDiffuseMap` texture, our fragment shader will also need the texture coordinates interpolated from the vertex data. Thus, we have to make sure the `vVertexUv` varying is properly filled by our vertex shader:
 
 ```c
-#ifdef GL_ES precision mediump float; #endif
+#ifdef GL_ES
+precision mediump float;
+#endif
 
-attribute vec3 aPosition; attribute vec2 aUv;
+attribute vec3 aPosition;
+attribute vec2 aUv;
 
 uniform mat4 uModelToWorldMatrix;
 uniform mat4 uWorldToScreenMatrix;

--- a/doc/tutorial/30-Applying_anti-aliasing_effect.md
+++ b/doc/tutorial/30-Applying_anti-aliasing_effect.md
@@ -67,7 +67,8 @@ Most effects needs some properties to be set to work properly. For the anti-alia
 -   **texcoordOffset**: that is the inverse of the texture dimensions along X and Y of the render target.
 
 ```cpp
-effect->setUniform("textureSampler", renderTarget); effect->setUniform("texcoordOffset", Vector2::create(1.0f / renderTarget->width(), 1.0f / renderTarget->height())); 
+effect->setUniform("textureSampler", renderTarget);
+effect->setUniform("texcoordOffset", Vector2::create(1.0f / renderTarget->width(), 1.0f / renderTarget->height())); 
 ```
 
 
@@ -77,7 +78,8 @@ Step 4 : Draw the scene
 The final initialization step is to create a second scene - completely different from your actual 3D scene - that will only hold a single surface made from the quad geometry that it supposed to represent our screen, a dummy Material and our post-processing effect:
 
 ```cpp
-auto renderer = Renderer::create(); auto postProcessingScene = scene::Node::create() ->addComponent(renderer) ->addComponent(
+auto renderer = Renderer::create();
+auto postProcessingScene = scene::Node::create() ->addComponent(renderer) ->addComponent(
 
    Surface::create(
        geometry::QuadGeometry::create(sceneManager->assets()->context()),

--- a/doc/tutorial/Compiling_the_SDK_for_OS_X.md
+++ b/doc/tutorial/Compiling_the_SDK_for_OS_X.md
@@ -16,21 +16,22 @@ Step 3: Generate the solution
 Minko uses Premake for its build system. Premake is a nice solution to have a cross-platform build system that can work across multiple IDEs such as Xcode, Visual Studio and even GNU Make. In order to build the SDK for OSX, we will generate a solution for `gmake`. We need to use a terminal to generate a `Makefile`-compatible solution:
 
 ```bash
-cd ${MINKO_HOME} tool/mac/scripts/premake5.sh gmake 
+cd ${MINKO_HOME}
+tool/mac/bin/premake5.sh gmake
 ```
 
 
 If we want to select your compiler, we can pass the `cc` option. Supported values are `gcc` and `clang`:
 
 ```bash
-tool/mac/scripts/premake5.sh --cc=clang gmake 
+tool/mac/bin/premake5.sh --cc=clang gmake
 ```
 
 
 To learn more about premake commands, run:
 
 ```bash
-tool/mac/scripts/premake5.sh help 
+tool/mac/bin/premake5.sh help
 ```
 
 
@@ -66,7 +67,7 @@ Step 5: Package
 The SDK is now built, but you might want to share or copy it so you don't have to deal with the sources again. We use a script to produce a distributable SDK.
 
 ```bash
-tool/mac/scripts/premake5.sh dist 
+tool/mac/bin/premake5.sh dist
 ```
 
 

--- a/doc/tutorial/Compiling_the_SDK_for_OS_X.md
+++ b/doc/tutorial/Compiling_the_SDK_for_OS_X.md
@@ -8,7 +8,7 @@ Make sure you have the source code of Minko on your filesystem. You can get them
 Step 2: Installing the toolchain
 --------------------------------
 
-If you've never build a Minko application or the Minko SDK for OSX before, follow the [step 1 of the Targeting OSX tutorial](../tutorial/Targeting_Windows.md#step-1-install-the-toolchain).
+If you've never build a Minko application or the Minko SDK for OSX before, follow the [step 1 of the Targeting OSX tutorial](../tutorial/Targeting_OS_X.md#step-1-install-the-toolchain).
 
 Step 3: Generate the solution
 -----------------------------

--- a/doc/tutorial/Installing_the_SDK.md
+++ b/doc/tutorial/Installing_the_SDK.md
@@ -81,7 +81,7 @@ Step 5: Installing toolsets
 Now the SDK sources are on your local machine, you can compile them. To do so, please read one of the following tutorials:
 
 -   To target Windows, follow the [Compiling the SDK for Windows](../tutorial/Compiling_the_SDK_for_Windows.md) tutorial.
--   To target OSX, follow the [Compiling the SDK for OSX](../tutorial/Compiling_the_SDK_for_OSX.md) tutorial.
+-   To target OS X, follow the [Compiling the SDK for OS X](../tutorial/Compiling_the_SDK_for_OS_X.md) tutorial.
 -   To target Linux, follow the [Compiling the SDK for Linux](../tutorial/Compiling_the_SDK_for_Linux.md) tutorial.
 -   To target HTML5, follow the [Compiling the SDK for HTML5](../tutorial/Compiling_the_SDK_for_HTML5.md) tutorial.
 -   To target iOS, follow the [Compiling the SDK for iOS](../tutorial/Compiling_the_SDK_for_iOS.md) tutorial.

--- a/doc/tutorial/Installing_the_SDK_sources.md
+++ b/doc/tutorial/Installing_the_SDK_sources.md
@@ -43,7 +43,7 @@ Where to go from there...
 Now the SDK sources are on your local machine, you can compile them. To do so, please read one of the following tutorials:
 
 -   To target Windows, follow the [Compiling the SDK for Windows](../tutorial/Compiling_the_SDK_for_Windows.md) tutorial.
--   To target OSX, follow the [Compiling the SDK for OSX](../tutorial/Compiling_the_SDK_for_OSX.md) tutorial.
+-   To target OS X, follow the [Compiling the SDK for OS X](../tutorial/Compiling_the_SDK_for_OS_X.md) tutorial.
 -   To target Linux, follow the [Compiling the SDK for Linux](../tutorial/Compiling_the_SDK_for_Linux.md) tutorial.
 -   To target HTML5, follow the [Compiling the SDK for HTML5](../tutorial/Compiling_the_SDK_for_HTML5.md) tutorial.
 -   To target iOS, follow the [Compiling the SDK for iOS](../tutorial/Compiling_the_SDK_for_iOS.md) tutorial.

--- a/skeleton/src/main.cpp
+++ b/skeleton/src/main.cpp
@@ -28,7 +28,7 @@ int main(int argc, char** argv)
 {
     auto canvas = Canvas::create("Minko Application", 800, 600);
 
-    auto sceneManager = SceneManager::create(canvas->context());
+    auto sceneManager = SceneManager::create(canvas);
 
     sceneManager->assets()->loader()
         ->queue("effect/Basic.effect");


### PR DESCRIPTION
This pull fixes the following issues in the tutorials:

* There were links to the windows pages for OS X
* The path to premake5.sh were incorrect on the OS X pages
* Missing newlines in a lot of the code sections

And makes the skeleton project compile again since a SceneManager API change.