### PR TITLE
[dev] ObjFile{Importer,Parser}: improve robustness & error reporting

### DIFF
--- a/plugin/assimp/lib/assimp/code/ObjFileImporter.cpp
+++ b/plugin/assimp/lib/assimp/code/ObjFileImporter.cpp
@@ -422,8 +422,7 @@ void ObjFileImporter::createVertexArray(const ObjFile::Model* pModel,
 			if ( !pModel->m_TextureCoord.empty() && vertexIndex < pSourceFace->m_pTexturCoords->size())
 			{
 				const unsigned int tex = pSourceFace->m_pTexturCoords->at( vertexIndex );
-				ai_assert( tex < pModel->m_TextureCoord.size() );
-					
+
 				if ( tex >= pModel->m_TextureCoord.size() )
 					throw DeadlyImportError("OBJ: texture coordinate index out of range");
 

--- a/plugin/assimp/lib/assimp/code/ObjFileParser.cpp
+++ b/plugin/assimp/lib/assimp/code/ObjFileParser.cpp
@@ -352,14 +352,14 @@ void ObjFileParser::getFace(aiPrimitiveType type)
 		else 
 		{
 			//OBJ USES 1 Base ARRAYS!!!!
-			const int iVal = atoi( pPtr );
+			char *pEnd;
+			const int iVal = strtol( pPtr, &pEnd, 10 );
 
-			// increment iStep position based off of the sign and # of digits
-			int tmp = iVal;
-			if (iVal < 0)
-			    ++iStep;
-			while ( ( tmp = tmp / 10 )!=0 )
-				++iStep;
+			iStep = pEnd - pPtr;
+			if (iStep == 0)
+			{
+				reportErrorTokenInFace();
+			}
 
 			if ( iVal > 0 )
 			{


### PR DESCRIPTION
These commits fix some minor issues in the OBJ parser. It should also improve error reporting for some edge cases.

This makes for example the output from [OBJExporter of ThreeJS](https://github.com/mrdoob/three.js/blob/master/examples/js/exporters/OBJExporter.js) work now.