### PR TITLE
Fix SDLAudio support

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -17,11 +17,6 @@ You can find the complete list and the status for each platform on our [Platform
 
 Make sure you check the following pages to get started:
 
--   [Developer reference](http://doc.v3.minko.io/reference/)
 -   [Tutorials](tutorial/README.md)
--   Examples
 -   [Articles](article/README.md)
-
-If you are looking for professional technical support, please [contact us](http://minko.io/contact)!
-
-You can find Minko 2 documentation [here](http://doc.v2.minko.io/wiki/Main_Page).
+-   [Examples](../example)

--- a/framework/src/minko/audio/PositionalSound.cpp
+++ b/framework/src/minko/audio/PositionalSound.cpp
@@ -31,7 +31,7 @@ using namespace minko::audio;
 void
 PositionalSound::update(scene::Node::Ptr target)
 {
-    if (!_channel->playing())
+    if (!_channel || !_channel->playing())
         return;
 
     static const auto zero = math::vec3(0.f);

--- a/plugin/sdl/src/minko/audio/SDLSound.cpp
+++ b/plugin/sdl/src/minko/audio/SDLSound.cpp
@@ -17,6 +17,7 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+#include "minko/audio/SDLAudio.hpp"
 #include "minko/audio/SDLSound.hpp"
 #include "minko/audio/SDLSoundChannel.hpp"
 #include "minko/audio/SoundTransform.hpp"

--- a/plugin/sdl/src/minko/audio/SoundParser.cpp
+++ b/plugin/sdl/src/minko/audio/SoundParser.cpp
@@ -18,6 +18,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 */
 
 #include "minko/audio/SoundParser.hpp"
+#include "minko/audio/SDLAudio.hpp"
 #include "minko/audio/SDLSound.hpp"
 #include "minko/file/AssetLibrary.hpp"
 #include "minko/log/Logger.hpp"


### PR DESCRIPTION
- Add missing headers to ensure SDL_AUDIO_ENABLED flag is seen correctly
- Check existence of _channel to prevent NPE on update

Alternatively, SDLSound.hpp could include SDLAudio.hpp
